### PR TITLE
Kafka 42 share consumerr

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -101,7 +101,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        version: [3.8.0,3.9.0,4.0.0]
+        version: [3.8.0,3.9.0,4.0.0,4.1.0]
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v6

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/clients/CloseableShareConsumer.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/clients/CloseableShareConsumer.java
@@ -63,6 +63,11 @@ public record CloseableShareConsumer<K, V>(ShareConsumer<K, V> instance) impleme
         instance.acknowledge(record, type);
     }
 
+     @Override
+     public void acknowledge(String topic, int partition, long offset, AcknowledgeType type) {
+         instance.acknowledge(topic, partition, offset, type);
+     }
+
     @Override
     public Map<TopicIdPartition, Optional<KafkaException>> commitSync() {
         return instance.commitSync();
@@ -87,6 +92,11 @@ public record CloseableShareConsumer<K, V>(ShareConsumer<K, V> instance) impleme
     public Uuid clientInstanceId(Duration timeout) {
         return instance.clientInstanceId(timeout);
     }
+
+     @Override
+     public Optional<Integer> acquisitionLockTimeoutMs() {
+         return instance.acquisitionLockTimeoutMs();
+     }
 
     @Override
     public Map<MetricName, ? extends Metric> metrics() {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -308,11 +308,14 @@ public class KafkaClusterConfig {
         configureSasl(nodeConfiguration);
 
         putConfig(nodeConfiguration, "offsets.topic.replication.factor", ONE_CONFIG);
-        // 1 partition for the __consumer_offsets_ topic should be enough
+        // 1 partition for the __consumer_offsets_ topic enables topic auto-creation to succeed on single-node clusters
         putConfig(nodeConfiguration, "offsets.topic.num.partitions", ONE_CONFIG);
-        // 1 partition for the __transaction_state_ topic should be enough
+        // 1 partition for the __transaction_state_ topic enables topic auto-creation to succeed on single-node clusters
         putConfig(nodeConfiguration, "transaction.state.log.replication.factor", ONE_CONFIG);
         putConfig(nodeConfiguration, "transaction.state.log.min.isr", ONE_CONFIG);
+        // 1 partition for the __share_group_state enables topic auto-creation to succeed on single-node clusters
+        putConfig(nodeConfiguration, "share.coordinator.state.topic.replication.factor", ONE_CONFIG);
+        putConfig(nodeConfiguration, "share.coordinator.state.topic.min.isr", ONE_CONFIG);
         // Disable delay during every re-balance
         putConfig(nodeConfiguration, "group.initial.rebalance.delay.ms", Integer.toString(0));
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -5,22 +5,23 @@
  */
 package io.kroxylicious.testing.kafka.invm;
 
-import kafka.server.KafkaConfig;
-import kafka.tools.StorageTool;
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.metadata.bootstrap.BootstrapMetadata;
 import org.apache.kafka.metadata.storage.Formatter;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
+
+import kafka.server.KafkaConfig;
+import kafka.tools.StorageTool;
 import scala.collection.immutable.Seq;
 import scala.jdk.javaapi.CollectionConverters;
-
-import java.io.PrintStream;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Optional;
 
 /**
  * Note that this code is base on code from Kafka's StorageTool.

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -5,23 +5,22 @@
  */
 package io.kroxylicious.testing.kafka.invm;
 
-import java.io.PrintStream;
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Optional;
-
+import kafka.server.KafkaConfig;
+import kafka.tools.StorageTool;
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.metadata.bootstrap.BootstrapMetadata;
 import org.apache.kafka.metadata.storage.Formatter;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.server.common.MetadataVersion;
-
-import kafka.server.KafkaConfig;
-import kafka.tools.StorageTool;
 import scala.collection.immutable.Seq;
 import scala.jdk.javaapi.CollectionConverters;
+
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Note that this code is base on code from Kafka's StorageTool.
@@ -80,19 +79,12 @@ final class KraftLogDirUtil {
     private static MetadataVersion getMetadataVersion(KafkaConfig config) {
         try {
             String version = ReflectionUtils.invokeInstanceMethod(config, "interBrokerProtocolVersionString");
-            return Optional.ofNullable(version).map(KraftLogDirUtil::getMetadataVersion).orElse(MetadataVersion.LATEST_PRODUCTION);
+            return Optional.ofNullable(version)
+                    .map(versionString -> (MetadataVersion) ReflectionUtils.invokeStaticMethod(MetadataVersion.class, "fromVersionString", versionString))
+                    .orElse(MetadataVersion.LATEST_PRODUCTION);
         }
         catch (Exception e) {
             return MetadataVersion.LATEST_PRODUCTION;
-        }
-    }
-
-    private static MetadataVersion getMetadataVersion(String versionString) {
-        try {
-            return MetadataVersion.fromVersionString(versionString, true);
-        }
-        catch (LinkageError | Exception exception) {
-            return ReflectionUtils.invokeStaticMethod(MetadataVersion.class, "fromVersionString", versionString);
         }
     }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -80,10 +80,19 @@ final class KraftLogDirUtil {
     private static MetadataVersion getMetadataVersion(KafkaConfig config) {
         try {
             String version = ReflectionUtils.invokeInstanceMethod(config, "interBrokerProtocolVersionString");
-            return Optional.ofNullable(version).map(MetadataVersion::fromVersionString).orElse(MetadataVersion.LATEST_PRODUCTION);
+            return Optional.ofNullable(version).map(KraftLogDirUtil::getMetadataVersion).orElse(MetadataVersion.LATEST_PRODUCTION);
         }
         catch (Exception e) {
             return MetadataVersion.LATEST_PRODUCTION;
+        }
+    }
+
+    private static MetadataVersion getMetadataVersion(String versionString) {
+        try {
+            return MetadataVersion.fromVersionString(versionString, true);
+        }
+        catch (LinkageError | Exception exception) {
+            return ReflectionUtils.invokeStaticMethod(MetadataVersion.class, "fromVersionString", versionString);
         }
     }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -266,7 +266,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         if (clusterConfig.isKafkaVersion41OrHigher()) {
             kafkaContainer
                     .withEnv("CLUSTER_ID", holder.kraftClusterId())
-                    .withCopyToContainer(Transferable.of(propertiesToBytes(properties), 0644), "/etc/kafka/docker/server.properties");
+                    .withCopyToContainer(Transferable.of(propertiesToBytes(properties), 0644), "/mnt/shared/config/server.properties");
         }
         else {
             kafkaContainer.withEnv("SERVER_PROPERTIES_FILE", "/cnf/server.properties")

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -383,6 +383,9 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         String defaultVersion;
         if (clusterConfig.isKafkaVersion41OrHigher()) {
             defaultVersion = clusterConfig.getKafkaVersion();
+            if (defaultVersion.equals("4.2.0")) {
+                defaultVersion = defaultVersion + "-rc1";
+            }
         }
         else if (MAJOR_MINOR_PATCH.matcher(clusterConfig.getKafkaVersion()).matches()) {
             defaultVersion = "latest-kafka-" + clusterConfig.getKafkaVersion();

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <skipUTs>${skipTests}</skipUTs>
 
         <junit.version>5.13.4</junit.version>
-        <kafka.version>4.1.1</kafka.version>
+        <kafka.version>4.2.0</kafka.version>
         <testcontainers.version>2.0.3</testcontainers.version>
         <lombok.version>1.18.42</lombok.version>
         <assertj-core.version>3.27.6</assertj-core.version>
@@ -762,6 +762,19 @@
             </build>
         </profile>
     </profiles>
+    <repositories>
+            <repository>
+                <id>apache-kafka-staging</id>
+                <name>Apache Kafka Staging Repository</name>
+                <url>https://repository.apache.org/content/groups/staging/</url>
+                <releases>
+                    <enabled>true</enabled>
+                </releases>
+                <snapshots>
+                    <enabled>false</enabled>
+                </snapshots>
+            </repository>
+        </repositories>
 
     <distributionManagement>
         <snapshotRepository>


### PR DESCRIPTION
Last commit makes the changes required for the CloseableShareConsumer to be compatible with Kafka 4.2